### PR TITLE
Replace Mol-Rep-Haskell-Bayes with MolADT-Bayes

### DIFF
--- a/index.md
+++ b/index.md
@@ -92,7 +92,7 @@ Toolkits
 | Indigo               | <http://lifescience.opensource.epam.com/indigo>                          |    GPL   |    A1    |          |
 | JoeLib               | <http://sourceforge.net/projects/joelib>                                 |    GPL   |    C1    |          |
 | LICSS                | <https://github.com/KevinLawson/excel-cdk>                               |    GPL   |    A2    |          |
-| Mol-Rep-Haskell-Bayes| <https://github.com/oliverjgoldstein/Mol-Rep-Haskell-Bayes>              |   AGPL3  |    A2    |          |
+| MolADT-Bayes         | <https://github.com/oliverjgoldstein/MolADT-Bayes/>                      |   Custom |    A1    |          |
 | MayaChemTools        | <http://www.mayachemtools.org>                                           |   LGPL   |    A2    |          |
 | Mychem               | <http://mychem.sourceforge.net>                                          |    GPL   |    B2    |          |
 | ODDT                 | <https://github.com/oddt/oddt>                                           |    BSD   |    A2    |          |


### PR DESCRIPTION
This is the new library which is more faithful to the Dietz representation. The newest version of the updates will soon appear on Arxiv. It is far more efficient and comes with a huge number of updates, making it efficient, easily parsable and well designed as a library.

https://arxiv.org/abs/2501.13633

This will soon be updated.